### PR TITLE
feat: add App Store and Google Play links to download sections

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -39,7 +39,7 @@ MiDiccio はあなたのプライバシーを尊重します：
 ## ダウンロード
 
 - [App Store (iOS)](https://apps.apple.com/jp/app/midiccio/id6759956689)
-- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio)
 
 ---
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -38,8 +38,8 @@ MiDiccio はあなたのプライバシーを尊重します：
 
 ## ダウンロード
 
-- App Store（iOS）— 準備中
-- Google Play（Android）— 準備中
+- [App Store (iOS)](https://apps.apple.com/jp/app/midiccio/id6759956689)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
 
 ---
 

--- a/INDEX_EN.md
+++ b/INDEX_EN.md
@@ -39,7 +39,7 @@ MiDiccio respects your privacy:
 ## Download
 
 - [App Store (iOS)](https://apps.apple.com/us/app/midiccio/id6759956689)
-- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio)
 
 ---
 

--- a/INDEX_EN.md
+++ b/INDEX_EN.md
@@ -38,8 +38,8 @@ MiDiccio respects your privacy:
 
 ## Download
 
-- App Store (iOS) — Coming soon
-- Google Play (Android) — Coming soon
+- [App Store (iOS)](https://apps.apple.com/us/app/midiccio/id6759956689)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
 
 ---
 

--- a/INDEX_ES.md
+++ b/INDEX_ES.md
@@ -38,8 +38,8 @@ MiDiccio respeta tu privacidad:
 
 ## Descargar
 
-- App Store (iOS) — Próximamente
-- Google Play (Android) — Próximamente
+- [App Store (iOS)](https://apps.apple.com/es/app/midiccio/id6759956689)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
 
 ---
 

--- a/INDEX_ES.md
+++ b/INDEX_ES.md
@@ -39,7 +39,7 @@ MiDiccio respeta tu privacidad:
 ## Descargar
 
 - [App Store (iOS)](https://apps.apple.com/es/app/midiccio/id6759956689)
-- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio)
 
 ---
 

--- a/INDEX_FR.md
+++ b/INDEX_FR.md
@@ -39,7 +39,7 @@ MiDiccio respecte votre vie privée :
 ## Télécharger
 
 - [App Store (iOS)](https://apps.apple.com/fr/app/midiccio/id6759956689)
-- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio)
 
 ---
 

--- a/INDEX_FR.md
+++ b/INDEX_FR.md
@@ -38,8 +38,8 @@ MiDiccio respecte votre vie privée :
 
 ## Télécharger
 
-- App Store (iOS) — Bientôt disponible
-- Google Play (Android) — Bientôt disponible
+- [App Store (iOS)](https://apps.apple.com/fr/app/midiccio/id6759956689)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
 
 ---
 

--- a/INDEX_IT.md
+++ b/INDEX_IT.md
@@ -38,8 +38,8 @@ MiDiccio rispetta la tua privacy:
 
 ## Scarica
 
-- App Store (iOS) — Prossimamente
-- Google Play (Android) — Prossimamente
+- [App Store (iOS)](https://apps.apple.com/it/app/midiccio/id6759956689)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
 
 ---
 

--- a/INDEX_IT.md
+++ b/INDEX_IT.md
@@ -39,7 +39,7 @@ MiDiccio rispetta la tua privacy:
 ## Scarica
 
 - [App Store (iOS)](https://apps.apple.com/it/app/midiccio/id6759956689)
-- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio&pcampaignid=web_share)
+- [Google Play (Android)](https://play.google.com/store/apps/details?id=jp.netplan.midiccio)
 
 ---
 


### PR DESCRIPTION
## Summary

- App Store URLを言語別に設定（JP/US/ES/FR/IT）
- Google Play URLを全言語共通で設定
- 「準備中 / Coming soon / Próximamente / ...」のプレースホルダーを実リンクに置き換え

## Test plan

- [ ] 各言語ページのApp Storeリンクが正しいストアに遷移することを確認
- [ ] Google Playリンクが正しく遷移することを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)