### PR TITLE
fix: set explicit dimensions on Google Play badge SVG (closes #13)

### DIFF
--- a/assets/badges/google-play-badge.svg
+++ b/assets/badges/google-play-badge.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="artwork" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 238.96 70.87">
+<svg id="artwork" xmlns="http://www.w3.org/2000/svg" version="1.1" width="135" height="40" viewBox="0 0 238.96 70.87">
   <!-- Generator: Adobe Illustrator 29.8.3, SVG Export Plug-In . SVG Version: 2.1.1 Build 3)  -->
   <defs>
     <style>


### PR DESCRIPTION
## Summary

- Google Play バッジ SVG に `width="135" height="40"` を追加
- `viewBox` のみだとブラウザが元サイズ（約239×71px）で描画してしまうため巨大表示になっていた
- App Store バッジ（高さ 40px）と同じ高さに揃えた

## Test plan

- [ ] Google Play バッジが App Store バッジと同程度のサイズで表示されること
- [ ] バッジのリンクが正常に動作すること

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)