### PR TITLE
fix: remove frame-ancestors from meta CSP and add SVG favicon (closes #15)

### DIFF
--- a/ci_scripts/build_privacy_policy_site.py
+++ b/ci_scripts/build_privacy_policy_site.py
@@ -70,7 +70,7 @@ def build_html(markdown_text: str, meta: dict[str, str]) -> str:
     csp_content = (
         "default-src 'none'; style-src 'unsafe-inline'; "
         "img-src https: data:; base-uri 'none'; "
-        "form-action 'none'; frame-ancestors 'none';"
+        "form-action 'none';"
     )
     extra_css = PROMO_CSS if page_type == "promo" else ""
 
@@ -83,6 +83,7 @@ def build_html(markdown_text: str, meta: dict[str, str]) -> str:
       http-equiv=\"Content-Security-Policy\"
       content=\"{html.escape(csp_content)}\"
     />
+    <link rel=\"icon\" type=\"image/svg+xml\" href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231a1a1a'/><text x='50' y='72' font-size='68' font-family='system-ui,sans-serif' font-weight='700' fill='white' text-anchor='middle'>M</text></svg>\" />
     <title>{html.escape(title)}</title>
     <meta name=\"description\" content=\"{html.escape(description)}\" />
     <style>

--- a/ci_scripts/build_privacy_policy_site.py
+++ b/ci_scripts/build_privacy_policy_site.py
@@ -73,6 +73,18 @@ def build_html(markdown_text: str, meta: dict[str, str]) -> str:
         "form-action 'none';"
     )
     extra_css = PROMO_CSS if page_type == "promo" else ""
+    favicon_svg = (
+        "data:image/svg+xml,"
+        "<svg%20xmlns='http://www.w3.org/2000/svg'"
+        "%20viewBox='0%200%20100%20100'>"
+        "<rect%20width='100'%20height='100'%20rx='20'"
+        "%20fill='%231a1a1a'/>"
+        "<text%20x='50'%20y='72'%20font-size='68'"
+        "%20font-family='system-ui,sans-serif'"
+        "%20font-weight='700'%20fill='white'"
+        "%20text-anchor='middle'>M</text>"
+        "</svg>"
+    )
 
     return f"""<!doctype html>
 <html lang=\"{html.escape(lang)}\">
@@ -83,7 +95,7 @@ def build_html(markdown_text: str, meta: dict[str, str]) -> str:
       http-equiv=\"Content-Security-Policy\"
       content=\"{html.escape(csp_content)}\"
     />
-    <link rel=\"icon\" type=\"image/svg+xml\" href=\"data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'><rect%20width='100'%20height='100'%20rx='20'%20fill='%231a1a1a'/><text%20x='50'%20y='72'%20font-size='68'%20font-family='system-ui,sans-serif'%20font-weight='700'%20fill='white'%20text-anchor='middle'>M</text></svg>\" />
+    <link rel=\"icon\" type=\"image/svg+xml\" href=\"{favicon_svg}\" />
     <title>{html.escape(title)}</title>
     <meta name=\"description\" content=\"{html.escape(description)}\" />
     <style>

--- a/ci_scripts/build_privacy_policy_site.py
+++ b/ci_scripts/build_privacy_policy_site.py
@@ -83,7 +83,7 @@ def build_html(markdown_text: str, meta: dict[str, str]) -> str:
       http-equiv=\"Content-Security-Policy\"
       content=\"{html.escape(csp_content)}\"
     />
-    <link rel=\"icon\" type=\"image/svg+xml\" href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231a1a1a'/><text x='50' y='72' font-size='68' font-family='system-ui,sans-serif' font-weight='700' fill='white' text-anchor='middle'>M</text></svg>\" />
+    <link rel=\"icon\" type=\"image/svg+xml\" href=\"data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'><rect%20width='100'%20height='100'%20rx='20'%20fill='%231a1a1a'/><text%20x='50'%20y='72'%20font-size='68'%20font-family='system-ui,sans-serif'%20font-weight='700'%20fill='white'%20text-anchor='middle'>M</text></svg>\" />
     <title>{html.escape(title)}</title>
     <meta name=\"description\" content=\"{html.escape(description)}\" />
     <style>


### PR DESCRIPTION
## Summary

- `frame-ancestors 'none'` を meta CSP から削除：仕様上 `<meta>` タグ経由では無視されるディレクティブのため、ブラウザのコンソール警告が出ていた（HTTP レスポンスヘッダーでのみ有効）
- favicon を data URI（SVG）で追加：ページが `/en/`・`/privacy-policy/` など異なる階層に存在するため、ファイルパス参照ではなく data URI として HTML に直接埋め込むことでパス問題を回避

## Test plan

- [ ] ブラウザのコンソールに `frame-ancestors` の警告が出ないこと
- [ ] タブに「M」の favicon が表示されること
- [ ] 日本語・英語・各プライバシーポリシーページすべてで favicon が表示されること

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)